### PR TITLE
Update JSON gem to avoid build errors on macOS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cork (0.2.0)
+    cork (0.3.0)
       colored2 (~> 3.1)
 
 GEM
@@ -15,9 +15,9 @@ GEM
       json
       simplecov
       url
-    colored2 (3.1.1)
+    colored2 (3.1.2)
     docile (1.1.5)
-    json (1.8.3)
+    json (1.8.6)
     metaclass (0.0.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -59,4 +59,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.13.6
+   1.17.3


### PR DESCRIPTION
The `json` 1.8.3 gem won’t build correctly on my system:

<details>
<summary>build log</summary>

```
current directory: /Users/jeff/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/json-1.8.3/ext/json/ext/generator
/Users/jeff/.rbenv/versions/2.5.3/bin/ruby -r ./siteconf20190128-7224-deu41s.rb extconf.rb
creating Makefile

current directory: /Users/jeff/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR=" clean

current directory: /Users/jeff/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
generator.c:861:25: error: use of undeclared identifier 'rb_cFixnum'
    } else if (klass == rb_cFixnum) {
                        ^
generator.c:863:25: error: use of undeclared identifier 'rb_cBignum'
    } else if (klass == rb_cBignum) {
                        ^
generator.c:975:5: warning: division by zero is undefined [-Wdivision-by-zero]
    rb_scan_args(argc, argv, "01", &opts);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2182:9: note: expanded from macro 'rb_scan_args'
        rb_scan_args0(argc,argvp,fmt,\
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2355:9: note: expanded from macro 'rb_scan_args0'
                     (rb_scan_args_verify(fmt, varc), vars))
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2240:11: note: expanded from macro 'rb_scan_args_verify'
        verify = rb_scan_args_verify_count(fmt, varc); \
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: (skipping 4 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2206:6: note: expanded from macro 'rb_scan_args_count_hash'
     rb_scan_args_count_block(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2201:6: note: expanded from macro 'rb_scan_args_count_block'
     rb_scan_args_count_end(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2197:12: note: expanded from macro 'rb_scan_args_count_end'
    ((vari)/(!fmt[ofs] || rb_scan_args_bad_format(fmt)))
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
generator.c:975:5: warning: division by zero is undefined [-Wdivision-by-zero]
    rb_scan_args(argc, argv, "01", &opts);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2182:9: note: expanded from macro 'rb_scan_args'
        rb_scan_args0(argc,argvp,fmt,\
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2355:9: note: expanded from macro 'rb_scan_args0'
                     (rb_scan_args_verify(fmt, varc), vars))
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2240:11: note: expanded from macro 'rb_scan_args_verify'
        verify = rb_scan_args_verify_count(fmt, varc); \
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: (skipping 4 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2206:6: note: expanded from macro 'rb_scan_args_count_hash'
     rb_scan_args_count_block(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2202:6: note: expanded from macro 'rb_scan_args_count_block'
     rb_scan_args_count_end(fmt, ofs+1, varc, vari+1))
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2197:12: note: expanded from macro 'rb_scan_args_count_end'
    ((vari)/(!fmt[ofs] || rb_scan_args_bad_format(fmt)))
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
generator.c:975:5: warning: division by zero is undefined [-Wdivision-by-zero]
    rb_scan_args(argc, argv, "01", &opts);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2182:9: note: expanded from macro 'rb_scan_args'
        rb_scan_args0(argc,argvp,fmt,\
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2355:9: note: expanded from macro 'rb_scan_args0'
                     (rb_scan_args_verify(fmt, varc), vars))
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2240:11: note: expanded from macro 'rb_scan_args_verify'
        verify = rb_scan_args_verify_count(fmt, varc); \
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: (skipping 4 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2207:6: note: expanded from macro 'rb_scan_args_count_hash'
     rb_scan_args_count_block(fmt, ofs+1, varc, vari+1))
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2201:6: note: expanded from macro 'rb_scan_args_count_block'
     rb_scan_args_count_end(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2197:12: note: expanded from macro 'rb_scan_args_count_end'
    ((vari)/(!fmt[ofs] || rb_scan_args_bad_format(fmt)))
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
generator.c:975:5: warning: division by zero is undefined [-Wdivision-by-zero]
    rb_scan_args(argc, argv, "01", &opts);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2182:9: note: expanded from macro 'rb_scan_args'
        rb_scan_args0(argc,argvp,fmt,\
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2355:9: note: expanded from macro 'rb_scan_args0'
                     (rb_scan_args_verify(fmt, varc), vars))
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2240:11: note: expanded from macro 'rb_scan_args_verify'
        verify = rb_scan_args_verify_count(fmt, varc); \
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: (skipping 4 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2206:6: note: expanded from macro 'rb_scan_args_count_hash'
     rb_scan_args_count_block(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2201:6: note: expanded from macro 'rb_scan_args_count_block'
     rb_scan_args_count_end(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2197:12: note: expanded from macro 'rb_scan_args_count_end'
    ((vari)/(!fmt[ofs] || rb_scan_args_bad_format(fmt)))
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
generator.c:975:5: warning: division by zero is undefined [-Wdivision-by-zero]
    rb_scan_args(argc, argv, "01", &opts);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2182:9: note: expanded from macro 'rb_scan_args'
        rb_scan_args0(argc,argvp,fmt,\
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2355:9: note: expanded from macro 'rb_scan_args0'
                     (rb_scan_args_verify(fmt, varc), vars))
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2240:11: note: expanded from macro 'rb_scan_args_verify'
        verify = rb_scan_args_verify_count(fmt, varc); \
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: (skipping 4 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2206:6: note: expanded from macro 'rb_scan_args_count_hash'
     rb_scan_args_count_block(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2201:6: note: expanded from macro 'rb_scan_args_count_block'
     rb_scan_args_count_end(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2197:12: note: expanded from macro 'rb_scan_args_count_end'
    ((vari)/(!fmt[ofs] || rb_scan_args_bad_format(fmt)))
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
generator.c:975:5: warning: division by zero is undefined [-Wdivision-by-zero]
    rb_scan_args(argc, argv, "01", &opts);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2182:9: note: expanded from macro 'rb_scan_args'
        rb_scan_args0(argc,argvp,fmt,\
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2355:9: note: expanded from macro 'rb_scan_args0'
                     (rb_scan_args_verify(fmt, varc), vars))
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2240:11: note: expanded from macro 'rb_scan_args_verify'
        verify = rb_scan_args_verify_count(fmt, varc); \
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: (skipping 5 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2206:6: note: expanded from macro 'rb_scan_args_count_hash'
     rb_scan_args_count_block(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2201:6: note: expanded from macro 'rb_scan_args_count_block'
     rb_scan_args_count_end(fmt, ofs, varc, vari) : \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jeff/.rbenv/versions/2.5.3/include/ruby-2.5.0/ruby/ruby.h:2197:12: note: expanded from macro 'rb_scan_args_count_end'
    ((vari)/(!fmt[ofs] || rb_scan_args_bad_format(fmt)))
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
6 warnings and 2 errors generated.
make: *** [generator.o] Error 1

make failed, exit code 2
```
</details>


For this PR, I simply ran `bundle update json` and committed the output to `Gemfile.lock`.